### PR TITLE
Allow for request options to be passed through to HTTP adapter

### DIFF
--- a/lib/mechanize/browser.ex
+++ b/lib/mechanize/browser.ex
@@ -494,6 +494,7 @@ defmodule Mechanize.Browser do
 
   * `:headers` - a list of additional headers for this request.
   * `:params` - a list of params to be merged into the `url`.
+  * `:options` - a list of request options for this  request.
 
   ## Examples
 
@@ -522,6 +523,15 @@ defmodule Mechanize.Browser do
   # GET https://www.example.com?search=mechanize&order=name
   ```
 
+  Request with custom options:
+
+  ```
+  Browser.request!(browser, :get, "https://www.example.com", "", options: [
+    recv_timeout: 500, ssl: [{:versions, [:'tlsv1.2']}
+  ])
+  # GET https://www.example.com?search=mechanize&order=name
+  ```
+
   """
   @spec request!(t(), :atom, String.t(), String.t() | {atom, any}, keyword) :: Mechanize.Page.t()
   def request!(browser, method, url, body \\ "", opts \\ [])
@@ -529,13 +539,15 @@ defmodule Mechanize.Browser do
   def request!(browser, method, url, body, opts) do
     {headers, opts} = Keyword.pop(opts, :headers, [])
     {params, _opts} = Keyword.pop(opts, :params, [])
+    {options, _opts} = Keyword.pop(opts, :options, [])
 
     request!(browser, %Request{
       method: method,
       url: url,
       body: body,
       headers: headers,
-      params: params
+      params: params,
+      options: options
     })
   end
 

--- a/lib/mechanize/form.ex
+++ b/lib/mechanize/form.ex
@@ -473,15 +473,18 @@ defmodule Mechanize.Form do
   ```
   See `click_button!/2` for a simpler way to do this.
   """
-  @spec submit!(t(), SubmitButton.t() | ImageInput.t()) :: Page.t()
-  def submit!(form, button \\ nil) do
+  @spec submit!(t(), SubmitButton.t() | ImageInput.t(), keyword()) :: Page.t()
+  def submit!(form, button \\ nil, opts \\ []) do
+    {options, _opts} = Keyword.pop(opts, :options, [])
+
     case method(form) do
       :post ->
         Mechanize.Browser.request!(
           browser(form),
           :post,
           action_url(form),
-          {:form, params(form.fields, button)}
+          {:form, params(form.fields, button)},
+          opts
         )
 
       :get ->
@@ -490,7 +493,7 @@ defmodule Mechanize.Form do
           :get,
           action_url(form),
           "",
-          params: params(form.fields, button)
+          params: params(form.fields, button), options: options
         )
     end
   end

--- a/lib/mechanize/http_adapter/httpoison.ex
+++ b/lib/mechanize/http_adapter/httpoison.ex
@@ -148,7 +148,7 @@ defmodule Mechanize.HTTPAdapter.Httpoison do
 
   @impl Mechanize.HTTPAdapter
   def request!(%Request{} = req) do
-    case HTTPoison.request(req.method, req.url, req.body, req.headers) do
+    case HTTPoison.request(req.method, req.url, req.body, req.headers, req.options) do
       {:ok, res} ->
         Response.new(body: res.body, headers: res.headers, code: res.status_code, url: req.url)
 

--- a/lib/mechanize/request.ex
+++ b/lib/mechanize/request.ex
@@ -2,18 +2,21 @@ defmodule Mechanize.Request do
   alias Mechanize.Header
 
   @default_params []
+  @default_options []
   @default_body ""
 
   @enforce_keys [:url]
-  defstruct method: :get, url: nil, headers: [], body: @default_body, params: @default_params
+  defstruct method: :get, url: nil, headers: [], body: @default_body, params: @default_params, options: @default_options
 
   @type body() :: {atom(), Enum.t()} | binary()
   @type params() :: Enum.t()
+  @type options() :: Enum.t()
   @type t :: %__MODULE__{
           method: atom(),
           url: binary(),
           params: params(),
           headers: Header.headers(),
+          options: options(),
           body: body()
         }
 


### PR DESCRIPTION
@gushonorato This PR allows for request options to be passed through to the HTTP adapter. Quick and dirty but it suits my needs, so I am using it on my project, but feel free to give feedback. 

FYI, I tried to update the typing to reflect the new function signatures, but I couldn't get dialyxir to pass. It looks like this may have been the case before this PR. What setup/command are you using to test the typings?

